### PR TITLE
Fix all compile-time warnings

### DIFF
--- a/cpuload.c
+++ b/cpuload.c
@@ -12,6 +12,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 
 float cpuload(int user, int nice, int sys, int idle) {

--- a/dcled.c
+++ b/dcled.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
+#include <ctype.h>
 #include <getopt.h>
 #include <time.h>
 #include <sys/select.h>
@@ -262,7 +263,11 @@ int open_usbdev(struct ledscreen *disp) {
 	}
 
 	if(debug) {
+#if LIBUSB_API_VERSION >= 0x01000106
+		libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, 3);
+#else
 		libusb_set_debug(NULL,3);
+#endif
 	}	
 
 	/* Fetch a list of all the available devices. */


### PR DESCRIPTION
Before this change:

```
  $ make
  gcc -c -g -O3 -Wunused-variable -DFONTDIR='"/usr/local/share/dcled"' \
                                  -DDCLEDVERSION='"2.2"' \
                                  -I/usr/include/libusb-1.0 dcled.c
  dcled.c: In function ‘open_usbdev’:
  dcled.c:265:3: warning: ‘libusb_set_debug’ is deprecated: \
                 Use libusb_set_option instead [-Wdeprecated-declarations]
     libusb_set_debug(NULL,3);
     ^~~~~~~~~~~~~~~~
  In file included from dcled.c:30:
  /usr/include/libusb-1.0/libusb.h:1300:18: note: declared here
   void LIBUSB_CALL libusb_set_debug(libusb_context *ctx, int level);
                    ^~~~~~~~~~~~~~~~
  dcled.c: In function ‘printBCDchar’:
  dcled.c:409:7: warning: implicit declaration of function ‘isdigit’ \
                 [-Wimplicit-function-declaration]
    if (!isdigit(c)) {
         ^~~~~~~
  dcled.c: In function ‘savefonts’:
  dcled.c:1375:30: warning: implicit declaration of function ‘isgraph’ \
                   [-Wimplicit-function-declaration]
      fprintf(out,"%02x %c ",i,(isgraph(i)?i:'.'));
                                ^~~~~~~
  gcc dcled.o -o dcled -g -lm -lusb-1.0
  gcc -c -g -O3 -Wunused-variable -DFONTDIR='"/usr/local/share/dcled"' \
                                  -DDCLEDVERSION='"2.2"' \
                                  -I/usr/include/libusb-1.0 cpuload.c
  cpuload.c: In function ‘main’:
  cpuload.c:85:7: warning: implicit declaration of function ‘strcmp’ \
                  [-Wimplicit-function-declaration]
     if(!strcmp(tag,"cpu ")) {
         ^~~~~~
  gcc cpuload.o -o cpuload -g -lm -lusb-1.0
  $
```

After this change:

```
  $ make
  gcc -c -g -O3 -Wunused-variable -DFONTDIR='"/usr/local/share/dcled"' \
                -DDCLEDVERSION='"2.2"' -I/usr/include/libusb-1.0 dcled.c
  gcc dcled.o -o dcled -g -lm -lusb-1.0
  gcc -c -g -O3 -Wunused-variable -DFONTDIR='"/usr/local/share/dcled"' \
                -DDCLEDVERSION='"2.2"' -I/usr/include/libusb-1.0 cpuload.c
  gcc cpuload.o -o cpuload -g -lm -lusb-1.0
  $
```